### PR TITLE
Add missing support for `React.ref` (previously `React.Ref.t`).

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 # master
+- Add missing support for `React.ref` (previously `React.Ref.t`).
 
 # 3.27.0
 - Add support for `.res[i]` files from the new Bucklescript Syntax. 

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -16,9 +16,6 @@ import * as Curry from 'bs-platform/lib/es6/curry.js';
 // $FlowExpectedError: Reason checked type sufficiently
 import * as HooksBS from './Hooks.bs';
 
-// flowlint-next-line nonstrict-import:off
-import type {ref as React_ref} from '../src/shims/ReactShim.shim';
-
 export type vehicle = {| +name: string |};
 
 export type cb = ({| +to: vehicle |}) => void;
@@ -29,7 +26,7 @@ export type callback<input,output> = (input) => output;
 
 export type testReactContext = React$Context<number>;
 
-export type testReactRef = React_ref<number>;
+export type testReactRef = {| current: (null | number) |};
 
 export type testDomRef = React$Ref<mixed>;
 

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -158,7 +158,7 @@ let translateConstr =
         EmitType.typeReactContext(~config, ~type_=paramTranslation.type_),
     }
 
-  | (["React", "Ref", "t"], [paramTranslation]) => {
+  | (["React", "Ref", "t"] | ["React", "ref"], [paramTranslation]) => {
       dependencies: paramTranslation.dependencies,
       type_: EmitType.typeReactRef(~type_=paramTranslation.type_),
     }


### PR DESCRIPTION
Fixes https://github.com/reason-association/genType/issues/439