### PR TITLE
Extend experimental option to specify the full extension of generated…

### DIFF
--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -49,16 +49,21 @@ let fileHeader = (~config, ~sourceFile) => {
 
 let generatedFilesExtension = (~config) =>
   switch (config.generatedFileExtension) {
-  | Some(s) => s
+  | Some(s) => Filename.remove_extension(s) /* from .foo.bar to .foo */
   | None => ".gen"
   };
 
-let outputFileSuffix = (~config) =>
-  switch (config.language) {
-  | Flow
-  | Untyped => generatedFilesExtension(~config) ++ ".js"
-  | TypeScript => generatedFilesExtension(~config) ++ ".tsx"
+let outputFileSuffix = (~config) => {
+  switch (config.generatedFileExtension) {
+  | Some(s) when Filename.extension(s) != "" /* double extension */ => s
+  | _ =>
+    switch (config.language) {
+    | Flow
+    | Untyped => generatedFilesExtension(~config) ++ ".js"
+    | TypeScript => generatedFilesExtension(~config) ++ ".tsx"
+    }
   };
+};
 
 let generatedModuleExtension = (~config) => generatedFilesExtension(~config);
 


### PR DESCRIPTION
… files.

E.g. adding `"generatedFileExtension": ".gen.ts"` under `"gentypeconfig"` will generaate `.gen.ts` files.

Notice: this option is experimental and can interferes with some features, e.g. importing components with "genType.import`.

See https://github.com/reason-association/genType/issues/453.